### PR TITLE
Add more methods for option handling

### DIFF
--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5293,16 +5293,16 @@ def SolverFor(logic, ctx=None, logFile=None):
     See https://smtlib.cs.uiowa.edu/ for the name of all available logics.
     """
 
-# Pending multiple solvers
-#     >>> s = SolverFor("QF_LIA")
-#     >>> x = Int('x')
-#     >>> s.add(x > 0)
-#     >>> s.add(x < 2)
-#     >>> s.check()
-#     sat
-#     >>> s.model()
-#     [x = 1]
-#     """
+    # Pending multiple solvers
+    # >>> s = SolverFor("QF_LIA")
+    # >>> x = Int('x')
+    # >>> s.add(x > 0)
+    # >>> s.add(x < 2)
+    # >>> s.check()
+    # sat
+    # >>> s.model()
+    # [x = 1]
+    # """
     solver = pc.Solver()
     solver.setLogic(logic)
     ctx = _get_ctx(ctx)

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5194,10 +5194,49 @@ class Solver(object):
         return "(and " + " ".join(a.sexpr() for a in self.assertions()) + ")"
 
     def set(self, **kwargs):
+        """Set an option on the solver. Wraps ``setOption()``.
+
+        >>> s = Solver()
+        >>> s.set(incremental="true")
+        """
+        self.setOption(**kwargs)
+    
+    def setOption(self, **kwargs):
+        """Set an option on the solver. The option value is passed as a string internally.
+        Boolean values are properly converted manually, all other types are convertes using ``str()``.
+
+        >>> s = Solver()
+        >>> s.set(incremental=True)
+        """
         for k, v in kwargs.items():
             _assert(isinstance(k, str), "non-string key " + str(k))
-            _assert(isinstance(v, str), "non-string key " + str(v))
+            if isinstance(v, bool):
+                v = "true" if v else "false"
+            elif not isinstance(v, str):
+                v = str(v)
             self.solver.setOption(k, v)
+
+    def getOption(self, name):
+        """Get the current value of an option from the solver. The value is returned as a string.
+        For type-safe querying use ``getOptionInfo()``.
+
+        >>> s = Solver()
+        >>> s.setOption(incremental=True)
+        >>> s.getOption("incremental")
+        true
+        """
+        return self.solver.getOption(name)
+    
+    def getOptionInfo(self, name):
+        """Get the current value of an option from the solver. The value is returned as a string.
+        For type-safe querying use ``getOptionInfo()``.
+
+        >>> s = Solver()
+        >>> s.setOption(incremental=True)
+        >>> s.getOption("incremental")
+        { 'type': bool, 'current': True, 'default': False }
+        """
+        return self.solver.getOptionInfo(name)
 
 
 def SolverFor(logic, ctx=None, logFile=None):

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -141,10 +141,11 @@ class Context(object):
 
     def __del__(self):
         self.solver = None
-    
+
     def reset(self):
-        """Fully reset the context. This actually destroys the solver object and recreates this.
-        **This invalidates all objects created within this context and using them will most likely crash.**
+        """Fully reset the context. This actually destroys the solver object and
+        recreates it. **This invalidates all objects created within this context
+        and using them will most likely crash.**
         """
         self.solver = pc.Solver()
         self.solver.setOption("produce-models", "true")
@@ -190,15 +191,15 @@ def main_ctx():
     >>> x.ctx == main_ctx()
     True
     """
-# Pending multiple solvers
-#    >>> c = Context()
-#    >>> c == main_ctx()
-#    False
-#    >>> x2 = Real('x', c)
-#    >>> x2.ctx == c
-#    True
-#    >>> eq(x, x2)
-#    False
+    # Pending multiple solvers
+    #    >>> c = Context()
+    #    >>> c == main_ctx()
+    #    False
+    #    >>> x2 = Real('x', c)
+    #    >>> x2.ctx == c
+    #    True
+    #    >>> eq(x, x2)
+    #    False
     global _main_ctx
     if _main_ctx is None:
         _main_ctx = Context()
@@ -5057,10 +5058,11 @@ class Solver(object):
         self.solver.resetAssertions()
         self.scopes = 0
         self.assertions_ = [[]]
-    
+
     def reset(self):
-        """Fully reset the solver. This actually destroys the solver object in the context and recreates this.
-        **This invalidates all objects created within this context and using them will most likely crash.**
+        """Fully reset the solver. This actually destroys the solver object in
+        the context and recreates this. **This invalidates all objects created
+        within this context and using them will most likely crash.**
         
         >>> s = Solver()
         >>> x = Int('x')
@@ -5223,10 +5225,11 @@ class Solver(object):
         >>> s.set(incremental="true")
         """
         self.setOption(**kwargs)
-    
+
     def setOption(self, **kwargs):
-        """Set an option on the solver. The option value is passed as a string internally.
-        Boolean values are properly converted manually, all other types are convertes using ``str()``.
+        """Set an option on the solver. The option value is passed as a string
+        internally. Boolean values are properly converted manually, all other
+        types are convertes using ``str()``.
 
         >>> main_ctx().reset()
         >>> s = Solver()
@@ -5241,8 +5244,8 @@ class Solver(object):
             self.solver.setOption(k, v)
 
     def getOption(self, name):
-        """Get the current value of an option from the solver. The value is returned as a string.
-        For type-safe querying use ``getOptionInfo()``.
+        """Get the current value of an option from the solver. The value is
+        returned as a string. For type-safe querying use ``getOptionInfo()``.
 
         >>> main_ctx().reset()
         >>> s = Solver()
@@ -5251,10 +5254,10 @@ class Solver(object):
         'true'
         """
         return self.solver.getOption(name)
-    
+
     def getOptionInfo(self, name):
-        """Get the current value of an option from the solver. The value is returned as a string.
-        For type-safe querying use ``getOptionInfo()``.
+        """Get the current value of an option from the solver. The value is
+        returned as a string. For type-safe querying use ``getOptionInfo()``.
 
         >>> main_ctx().reset()
         >>> s = Solver()
@@ -5273,16 +5276,16 @@ def SolverFor(logic, ctx=None, logFile=None):
     See https://smtlib.cs.uiowa.edu/ for the name of all available logics.
     """
 
-    # Pending multiple solvers
-    #     >>> s = SolverFor("QF_LIA")
-    #     >>> x = Int('x')
-    #     >>> s.add(x > 0)
-    #     >>> s.add(x < 2)
-    #     >>> s.check()
-    #     sat
-    #     >>> s.model()
-    #     [x = 1]
-    #     """
+# Pending multiple solvers
+#     >>> s = SolverFor("QF_LIA")
+#     >>> x = Int('x')
+#     >>> s.add(x > 0)
+#     >>> s.add(x < 2)
+#     >>> s.check()
+#     sat
+#     >>> s.model()
+#     [x = 1]
+#     """
     solver = pc.Solver()
     solver.setLogic(logic)
     ctx = _get_ctx(ctx)

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -6226,7 +6226,7 @@ def set_default_rounding_mode(rm, ctx=None):
     """
     global _dflt_rounding_mode
     _assert(is_fprm_value(rm), "illegal rounding mode")
-    _dflt_rounding_mode = rm.ast
+    _dflt_rounding_mode = rm.ast.getRoundingModeValue()
 
 
 def get_default_fp_sort(ctx=None):

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5268,7 +5268,7 @@ class Solver(object):
 
         >>> s = Solver()
         >>> s.getOptionNames()[:3]
-        ['']
+        ['abstract-values', 'ackermann', 'approx-branch-depth']
         """
         return self.solver.getOptionNames()
 
@@ -5278,9 +5278,9 @@ class Solver(object):
 
         >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.setOption(incremental=False)
+        >>> s.setOption(incremental=True)
         >>> s.getOptionInfo("incremental")
-        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': False}
+        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': True, 'default': False}
         """
         return self.solver.getOptionInfo(name)
 

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5217,24 +5217,31 @@ class Solver(object):
         """
         return "(and " + " ".join(a.sexpr() for a in self.assertions()) + ")"
 
-    def set(self, **kwargs):
+    def set(self, *args, **kwargs):
         """Set an option on the solver. Wraps ``setOption()``.
 
         >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.set(incremental="true")
+        >>> s.set(incremental=True)
+        >>> s.set('incremental', 'true')
         """
-        self.setOption(**kwargs)
+        self.setOption(*args, **kwargs)
 
-    def setOption(self, **kwargs):
-        """Set an option on the solver. The option value is passed as a string
-        internally. Boolean values are properly converted manually, all other
-        types are convertes using ``str()``.
+    def setOption(self, name=None, value=None, **kwargs):
+        """Set options on the solver. Options can either be set via the ``name``
+        and ``value`` arguments in the form ``setOption('foo', 'bar')``, or as
+        keyword arguments using the syntax ``setOption(foo='bar')``.
+        The option value is passed as a string internally. Boolean values are
+        properly converted manually, all other types are convertes using
+        ``str()``.
 
         >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.set(incremental=True)
+        >>> s.setOption('incremental', True)
+        >>> s.setOption(incremental='true')
         """
+        if name is not None:
+            kwargs[name] = value
         for k, v in kwargs.items():
             _assert(isinstance(k, str), "non-string key " + str(k))
             if isinstance(v, bool):

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5254,6 +5254,16 @@ class Solver(object):
         'true'
         """
         return self.solver.getOption(name)
+    
+    def getOptionNames(self):
+        """Get all option names that can be used with ``getOption()``,
+        ``setOption()`` and ``getOptionInfo()``.
+
+        >>> s = Solver()
+        >>> s.getOptionNames()[:3]
+        ['']
+        """
+        return self.solver.getOptionNames()
 
     def getOptionInfo(self, name):
         """Get the current value of an option from the solver. The value is

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5027,9 +5027,7 @@ class Solver(object):
     def num_scopes(self):
         """Return the current number of backtracking points.
 
-        >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.setOption(incremental=True)
         >>> s.num_scopes()
         0
         >>> s.push()
@@ -5283,6 +5281,7 @@ class Solver(object):
         >>> s.setOption(incremental=False)
         >>> s.getOptionInfo("incremental")
         {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': True}
+        >>> main_ctx().reset()
         """
         return self.solver.getOptionInfo(name)
 

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -191,15 +191,15 @@ def main_ctx():
     >>> x.ctx == main_ctx()
     True
     """
-    # Pending multiple solvers
-    #    >>> c = Context()
-    #    >>> c == main_ctx()
-    #    False
-    #    >>> x2 = Real('x', c)
-    #    >>> x2.ctx == c
-    #    True
-    #    >>> eq(x, x2)
-    #    False
+# Pending multiple solvers
+#    >>> c = Context()
+#    >>> c == main_ctx()
+#    False
+#    >>> x2 = Real('x', c)
+#    >>> x2.ctx == c
+#    True
+#    >>> eq(x, x2)
+#    False
     global _main_ctx
     if _main_ctx is None:
         _main_ctx = Context()

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -6191,7 +6191,7 @@ def is_fprm_value(a):
 
 
 # Global default rounding mode
-_dflt_rounding_mode = RTZ()
+_dflt_rounding_mode = pc.RoundingMode.RoundTowardZero
 _dflt_fpsort_ebits = 11
 _dflt_fpsort_sbits = 53
 
@@ -6199,8 +6199,9 @@ _dflt_fpsort_sbits = 53
 def get_default_rounding_mode(ctx=None):
     """Retrieves the global default rounding mode."""
     if debugging():
-        _assert(isinstance(_dflt_rounding_mode, FPRMRef), "illegal rounding mode")
-    return _dflt_rounding_mode
+        _assert(isinstance(_dflt_rounding_mode, pc.RoundingMode), "illegal rounding mode")
+    ctx = _get_ctx(ctx)
+    return FPRMRef(ctx.solver.mkRoundingMode(_dflt_rounding_mode), ctx)
 
 
 def set_default_rounding_mode(rm, ctx=None):
@@ -6224,7 +6225,7 @@ def set_default_rounding_mode(rm, ctx=None):
     """
     global _dflt_rounding_mode
     _assert(is_fprm_value(rm), "illegal rounding mode")
-    _dflt_rounding_mode = rm
+    _dflt_rounding_mode = rm.ast
 
 
 def get_default_fp_sort(ctx=None):

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5278,9 +5278,9 @@ class Solver(object):
 
         >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.setOption(incremental=True)
+        >>> s.setOption(incremental=False)
         >>> s.getOptionInfo("incremental")
-        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': True, 'default': False}
+        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': False}
         """
         return self.solver.getOptionInfo(name)
 

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5248,7 +5248,7 @@ class Solver(object):
         >>> s = Solver()
         >>> s.setOption(incremental=True)
         >>> s.getOption("incremental")
-        true
+        'true'
         """
         return self.solver.getOption(name)
     
@@ -5258,9 +5258,9 @@ class Solver(object):
 
         >>> main_ctx().reset()
         >>> s = Solver()
-        >>> s.setOption(incremental=True)
+        >>> s.setOption(incremental=False)
         >>> s.getOptionInfo("incremental")
-        { 'type': bool, 'current': True, 'default': False }
+        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': False}
         """
         return self.solver.getOptionInfo(name)
 

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5293,16 +5293,16 @@ def SolverFor(logic, ctx=None, logFile=None):
     See https://smtlib.cs.uiowa.edu/ for the name of all available logics.
     """
 
-    # Pending multiple solvers
-    # >>> s = SolverFor("QF_LIA")
-    # >>> x = Int('x')
-    # >>> s.add(x > 0)
-    # >>> s.add(x < 2)
-    # >>> s.check()
-    # sat
-    # >>> s.model()
-    # [x = 1]
-    # """
+# Pending multiple solvers
+# >>> s = SolverFor("QF_LIA")
+# >>> x = Int('x')
+# >>> s.add(x > 0)
+# >>> s.add(x < 2)
+# >>> s.check()
+# sat
+# >>> s.model()
+# [x = 1]
+# """
     solver = pc.Solver()
     solver.setLogic(logic)
     ctx = _get_ctx(ctx)

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -5027,7 +5027,9 @@ class Solver(object):
     def num_scopes(self):
         """Return the current number of backtracking points.
 
+        >>> main_ctx().reset()
         >>> s = Solver()
+        >>> s.setOption(incremental=True)
         >>> s.num_scopes()
         0
         >>> s.push()
@@ -5280,7 +5282,7 @@ class Solver(object):
         >>> s = Solver()
         >>> s.setOption(incremental=False)
         >>> s.getOptionInfo("incremental")
-        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': False}
+        {'name': 'incremental', 'aliases': [], 'setByUser': True, 'type': <class 'bool'>, 'current': False, 'default': True}
         """
         return self.solver.getOptionInfo(name)
 


### PR DESCRIPTION
This PR adds wrappers for `setOption()`, `getOption`, `getOptionNames()` and `getOptionInfo()`.
It also extends `setOption()` (and `set()`) to allow for `setOption('name', 'value')` in addition to keywords to simplify setting options whose names contain dashes.