### PR TITLE
Cancel already running CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # cancel already running jobs for the same branch/pr/tag
+    concurrency:
+      group: build-${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
 
     - uses: actions/checkout@v2


### PR DESCRIPTION
This adapts the technique we use in the cvc5 repository to cancel CI jobs from previous commits on the same branch/PR that are still running. This saves CI time and some trees...