### PR TITLE
Rename some datatype functions

### DIFF
--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -7553,7 +7553,7 @@ class DatatypeConstructorRef(FuncDeclRef):
         >>> List.constructor(0).domain(0)
         Int
         """
-        return _to_sort_ref(self.ast.getSort().getConstructorDomainSorts()[i], self.ctx)
+        return _to_sort_ref(self.ast.getSort().getDatatypeConstructorDomainSorts()[i], self.ctx)
 
     def range(self):
         """Return the sort of the range of a function declaration.

--- a/cvc5_z3py_compat/z3.py
+++ b/cvc5_z3py_compat/z3.py
@@ -7568,7 +7568,7 @@ class DatatypeConstructorRef(FuncDeclRef):
         >>> List.constructor(0).range()
         List
         """
-        return _to_sort_ref(self.ast.getSort().getConstructorCodomainSort(), self.ctx)
+        return _to_sort_ref(self.ast.getSort().getDatatypeConstructorCodomainSort(), self.ctx)
 
     def __call__(self, *args):
         """Apply this constructor.
@@ -7607,13 +7607,13 @@ class DatatypeSelectorRef(FuncDeclRef):
         This method assumes that `0 <= i < self.arity()`.
         """
         _assert(i == 0, "Selectors take 1 argument")
-        return _to_sort_ref(self.ast.getSort().getSelectorDomainSort(), self.ctx)
+        return _to_sort_ref(self.ast.getSort().getDatatypeSelectorDomainSort(), self.ctx)
 
     def range(self):
         """Return the sort of the range of a function declaration.
         For constants, this is the sort of the constant.
         """
-        return _to_sort_ref(self.ast.getSort().getSelectorCodomainSort(), self.ctx)
+        return _to_sort_ref(self.ast.getSort().getDatatypeSelectorCodomainSort(), self.ctx)
 
     def __call__(self, *args):
         """Apply this selector.
@@ -7651,7 +7651,7 @@ class DatatypeRecognizerRef(FuncDeclRef):
         This method assumes that `0 <= i < self.arity()`.
         """
         _assert(i == 0, "Recognizers take 1 argument")
-        return _to_sort_ref(self.ast.getSort().getTesterDomainSort(), self.ctx)
+        return _to_sort_ref(self.ast.getSort().getDatatypeTesterDomainSort(), self.ctx)
 
     def range(self):
         """Return the sort of the range of a function declaration.


### PR DESCRIPTION
This fixes issues following renamed functions in the base python API.