### PR TITLE
Change import for Python APIs

### DIFF
--- a/test/pgms/example_exceptions.py
+++ b/test/pgms/example_exceptions.py
@@ -1,4 +1,4 @@
-from cvc5_pythonic_api import *
+from cvc5.pythonic import *
 
 if __name__ == '__main__':
     s = Solver()


### PR DESCRIPTION
The original import does not work for me, so I updated it like other pythonic examples (e.g., https://github.com/cvc5/cvc5/blob/main/examples/api/python/pythonic/helloworld.py)

Also, I am curious what the point in setting `s.set("produce-models", True)` in this example -- does it change anything?