### PR TITLE
Add FuncDeclRef case to _to_expr_ref

### DIFF
--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -1004,6 +1004,8 @@ def _to_expr_ref(a, ctx, r=None):
         return StringRef(ast, ctx, r)
     if sort.isSequence():
         return SeqRef(ast, ctx, r)
+    if sort.isFunction():
+        return FuncDeclRef(ast, ctx, r)
     return ExprRef(ast, ctx, r)
 
 


### PR DESCRIPTION
`_to_expr_ref` is our generic expression builder. It wraps a term in a sort-specific class that has methods suitable for the term's sort.

Previously, _to_expr_ref did not give function terms the right wrapper. Now, it does.

Fixes a bug latent in: https://github.com/cvc5/cvc5/issues/9983