### PR TITLE
Add support for DatatypeSort

### DIFF
--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -8688,14 +8688,11 @@ def CreateDatatypes(*ds):
         result.append(dref)
     return tuple(result)
 
-class DatatypeSort:
-    """Unresolved datatype sorts."""
-    
-    def __init__(self, name, ctx=None):
-        self.name = name
-        self.ctx = _get_ctx(ctx)
-        self.ast = self.ctx.tm.mkUnresolvedDatatypeSort(name)
-        
+def DatatypeSort(name, ctx=None):
+    """Create a reference to a sort that will be declared as a recursive datatype"""
+    ctx = _get_ctx(ctx)
+    s = ctx.tm.mkUnresolvedDatatypeSort(name)
+    return SortRef(s, ctx)
 
 class DatatypeSortRef(SortRef):
     """Datatype sorts."""

--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -8688,6 +8688,14 @@ def CreateDatatypes(*ds):
         result.append(dref)
     return tuple(result)
 
+class DatatypeSort:
+    """Unresolved datatype sorts."""
+    
+    def __init__(self, name, ctx=None):
+        self.name = name
+        self.ctx = _get_ctx(ctx)
+        self.ast = self.ctx.tm.mkUnresolvedDatatypeSort(name)
+        
 
 class DatatypeSortRef(SortRef):
     """Datatype sorts."""

--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -8688,11 +8688,13 @@ def CreateDatatypes(*ds):
         result.append(dref)
     return tuple(result)
 
+
 def DatatypeSort(name, ctx=None):
     """Create a reference to a sort that will be declared as a recursive datatype"""
     ctx = _get_ctx(ctx)
     s = ctx.tm.mkUnresolvedDatatypeSort(name)
     return SortRef(s, ctx)
+
 
 class DatatypeSortRef(SortRef):
     """Datatype sorts."""

--- a/test/pgm_outputs/example_datatypes.py.out
+++ b/test/pgm_outputs/example_datatypes.py.out
@@ -13,3 +13,6 @@ t is a 'cons': True
 
 [a = 51]
 proved
+
+Sorts match: True
+Operation on resolved sort works: True

--- a/test/pgms/example_datatypes.py
+++ b/test/pgms/example_datatypes.py
@@ -42,3 +42,18 @@ if __name__ == '__main__':
     solve(List.head(List.cons(a, List.nil)) > 50)
 
     prove(Not(List.is_nil(List.cons(a, List.nil))))
+
+    print()
+
+    # Test DatatypeSort for unresolved datatype sorts.
+    SomeType = Datatype('SomeType')
+    SomeTypeSort = DatatypeSort('SomeType')
+    SomeType.declare('nil')
+    SomeType.declare('some', ('someof', SeqSort(SomeTypeSort), ))
+    SomeTypeSort = SomeType.create()
+
+    nil = SomeTypeSort.nil
+    some = SomeTypeSort.some(Unit(nil))
+
+    print("Sorts match:", SomeTypeSort == SomeTypeSort.someof(some)[0].sort())
+    print("Operation on resolved sort works:", simplify(SomeTypeSort.is_nil(SomeTypeSort.someof(some)[0])))


### PR DESCRIPTION
This adds support for the (confusingly named) `DatatypeSort` function/class that is used to create unresolved datatype sorts in the Z3 Python API.

This closes https://github.com/cvc5/cvc5_pythonic_api/issues/109