### PR TITLE
Fix support for small floats

### DIFF
--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -3507,6 +3507,12 @@ def RealVal(val, ctx=None):
     3/2
     """
     ctx = _get_ctx(ctx)
+    if isinstance(val, float):
+        if abs(val) > 1e-10:
+            return RatNumRef(ctx.tm.mkReal(f"{val:.10f}"), ctx)
+        else:
+            num, den = val.as_integer_ratio()
+            return RatVal(num, den, ctx)
     return RatNumRef(ctx.tm.mkReal(str(val)), ctx)
 
 


### PR DESCRIPTION
This solves the issue with `RealVal` where some smaller values (in absolute terms) would cause an issue when converted to string, since they use the scientific notation.
Alternatively, the mkReal should be updated to support the `e` notation.

Some examples that would be fixed by this change:

```py
cvc5.pythonic.RealVal(1e-5) # => "0.0000100000"
"1/100000"
cvc5.pythonic.RealVal(-1e-5) # => "-0.0000100000"
"-1/100000"
cvc5.pythonic.RealVal(1e-50)
"8424983333484575/842498333348457493583344221469363458551160763204392890034487820288"
cvc5.pythonic.RealVal(-1e-50)
"-8424983333484575/842498333348457493583344221469363458551160763204392890034487820288"
```