### PR TITLE
Update the multiple_solvers test output

### DIFF
--- a/test/pgm_outputs/multiple_solvers.py.out
+++ b/test/pgm_outputs/multiple_solvers.py.out
@@ -1,9 +1,9 @@
 [x = 0, y = 0]
 sat
 0
-The logic was specified as QF_BV, which doesn't include THEORY_ARITH, but got a theory atom for that theory.
-The atom:
-(= x (* 2 y))
+The logic was specified as QF_BV, which doesn't include THEORY_ARITH, but got a preprocessing-time term for that theory.
+The term:
+(* 2 y)
 Can't solve integer problems with QF_BV solver
 got an exception, which is good
 unsat


### PR DESCRIPTION
CI has been failing on `main` since cvc5 changed the error message reported when a term outside the declared logic reaches preprocessing:

```diff
-The logic was specified as QF_BV, which doesn't include THEORY_ARITH, but got a theory atom for that theory.
-The atom:
-(= x (* 2 y))
+The logic was specified as QF_BV, which doesn't include THEORY_ARITH, but got a preprocessing-time term for that theory.
+The term:
+(* 2 y)
```

The term printed is now the offending subterm `(* 2 y)` rather than the enclosing atom `(= x (* 2 y))`. This refreshes the expected output, same as #112 did for `getOptionInfo`.

`multiple_solvers.py` is the only example affected; the full suite passes with this change.
