### PR TITLE
Build assertion messages only when the assertion fails

### DIFF
--- a/cvc5_pythonic_api/cvc5_pythonic.py
+++ b/cvc5_pythonic_api/cvc5_pythonic.py
@@ -760,10 +760,10 @@ def is_sort(s):
 
 
 def instance_check(item, instance):
-    _assert(
-        isinstance(item, instance),
-        "Expected {}, but got a {}".format(instance, type(item)),
-    )
+    # The message is built only on failure. Formatting it up front costs most
+    # of the time this check takes, and it is on the path of every `sort()`.
+    if not isinstance(item, instance):
+        raise SMTException("Expected {}, but got a {}".format(instance, type(item)))
 
 
 def _to_sort_ref(s, ctx):
@@ -957,11 +957,11 @@ def _higherorder_apply(func, args, kind):
     """Create an SMT application from a FuncDeclRef and a kind of application"""
     args = _get_args(args)
     num = len(args)
-    if debugging():
-        _assert(
-            num == func.arity(),
-            "Incorrect number of arguments to %s" % func,
-        )
+    # The message is built only on failure: printing `func` is a quarter of
+    # the time an application takes, and it can raise for a function that the
+    # printer has no case for.
+    if debugging() and num != func.arity():
+        raise SMTException("Incorrect number of arguments to %s" % func)
     _args = []
     for i in range(num):
         tmp = func.domain(i).cast(args[i])
@@ -6399,7 +6399,8 @@ class Solver(object):
         if name is not None:
             kwargs[name] = value
         for k, v in kwargs.items():
-            _assert(isinstance(k, str), "non-string key " + str(k))
+            if not isinstance(k, str):
+                raise SMTException("non-string key " + str(k))
             if isinstance(v, bool):
                 v = "true" if v else "false"
             elif not isinstance(v, str):
@@ -8752,11 +8753,8 @@ def CreateDatatypes(*ds):
                 fname = fs[k][0]
                 ftype = fs[k][1]
                 if isinstance(ftype, Datatype):
-                    if debugging():
-                        _assert(
-                            ftype.name in uninterp_sorts,
-                            "Missing datatype: " + ftype.name,
-                        )
+                    if debugging() and ftype.name not in uninterp_sorts:
+                        raise SMTException("Missing datatype: " + ftype.name)
                     ftype = uninterp_sorts[ftype.name]
                 else:
                     if debugging():


### PR DESCRIPTION
`_assert` takes an already-built message, so every caller that formats one pays for it whether or not the check passes. Two of those sit on paths taken constantly:

- `instance_check` — reached from `_sort`, and so from every `sort()` call
- `_higherorder_apply` — reached from every function application

In both, building the message costs more than everything else the check does. Printing the operand is the expensive part: `"%s" % func` measures at ~3.3 µs, against ~0.2 µs for the comparison it decorates.

## Change

Move the formatting behind the failing branch, written the way the rest of the file already writes checks whose message is computed (`_assert(False, ...)` under an `if`). Four sites in total; the other two are cold, but left inconsistent they invite the pattern back.

The condition, the message text, and the exception type are all unchanged. I diffed the raised errors against `main` for each of the four:

```
SMTException: Expected <class 'cvc5.cvc5_python_base.Term'>, but got a <class 'int'>
SMTException: Incorrect number of arguments to f
SMTException: non-string key 5
SMTException: Missing datatype: E
```

Identical before and after.

## Effect

Term building gets 2–4x faster. Three alternating runs of each, 20k iterations per measurement:

|  | main | this PR | |
|---|---|---|---|
| `x.sort()` | 1.73 / 1.59 / 1.80 | 0.48 / 0.46 / 0.42 | 3.8x |
| `f(x)` | 14.55 / 12.80 / 14.73 | 5.29 / 5.18 / 4.73 | 2.8x |
| `x + y` | 10.37 / 9.16 / 10.49 | 3.51 / 3.39 / 3.10 | 3.0x |
| `x == y` | 10.35 / 9.19 / 10.54 | 3.50 / 3.40 / 3.08 | 3.0x |
| `a[x]` | 7.58 / 6.66 / 7.63 | 3.67 / 3.67 / 3.27 | 2.1x |
| `And(x==1, y==2)` | 27.42 / 24.18 / 27.76 | 14.00 / 14.10 / 12.20 | 2.0x |

(microseconds per call)

The two fixes compound: an application coerces each argument through `domain(i).cast(...)`, which goes through `_sort` and so through `instance_check` as well.

## Correctness, not just speed

Formatting the operand can itself raise, which turns a *passing* assertion into an error. Printing a term whose kind the printer has no case for fails, so the check reports the wrong problem — or invents one where there is none. Building the message only on the failing path removes that class of bug from every one of these sites.

## Testing

- `test_doc.py`: 0 failures.
- `test_unit.py`: OK.
- `black --check --required-version 24`: clean.
- `pyright`: 633 errors, unchanged from main.
- Raised errors diffed against `main` for all four sites, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
